### PR TITLE
fix(add all): Change dot for dash A on git add

### DIFF
--- a/src/CreateConventionalCommit.php
+++ b/src/CreateConventionalCommit.php
@@ -15,7 +15,7 @@ class CreateConventionalCommit
     public function __invoke(Subject $subject, Body $body, Footer $footer, bool $addAllToStage): void
     {
         if ($addAllToStage) {
-            $this->exec('git add .');
+            $this->exec('git add -A');
         }
 
         $safeSubject = escapeshellarg((string)$subject);

--- a/tests/Unit/CreateConventionalCommitTest.php
+++ b/tests/Unit/CreateConventionalCommitTest.php
@@ -41,7 +41,7 @@ final class CreateConventionalCommitTest extends TestCase
             ->expects($this->exactly(2))
             ->method('exec')
             ->withConsecutive(
-                [$this->equalTo('git add .')],
+                [$this->equalTo('git add -A')],
                 [$this->equalTo("git commit -m 'subject' -m 'body' -m 'footer'")]
             );
 


### PR DESCRIPTION
This change must prevent that someone create a new commit inside a
directory, the `git add .` only adds the current directory, `git add -A`
adds all the files in the repository