### PR TITLE
feat(config): Replace merge by merge recursive

### DIFF
--- a/src/CommitCommand.php
+++ b/src/CommitCommand.php
@@ -119,7 +119,7 @@ class CommitCommand extends Command
             throw new InvalidArgumentException('Custom configuration file must return an array');
         }
 
-        return Configuration::fromArray(array_merge($this->configuration, $customConfiguration));
+        return Configuration::fromArray(array_merge_recursive($this->configuration, $customConfiguration));
     }
 
     private function createType(InputInterface $input, OutputInterface $output, Configuration $configuration): Type


### PR DESCRIPTION
This change should allows people to create configurations files with
only needed params

Ex:

My local config file
```php
<?php

return [
    'type' => [
        'values' => [
            'feat',
            'fix',
            'docs',
            'refactor',
            'test',
            'ci',
        ],
    ],
];

```

I'm only overwriting the [type][values] configuration and taking the default value for other keys from this library